### PR TITLE
Clarify encoding of varuint32 values.

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -39,7 +39,7 @@ A two-byte little endian unsigned integer.
 A four-byte little endian unsigned integer.
 
 ### varuint32
-A [LEB128](https://en.wikipedia.org/wiki/LEB128) variable-length integer, limited to uint32 values.
+A [LEB128](https://en.wikipedia.org/wiki/LEB128) variable-length integer, limited to uint32 values. `varuint32` values may contain leading zeros.
 
 ### value_type
 A single-byte unsigned integer indicating a [value type](AstSemantics.md#types). These types are encoded as:


### PR DESCRIPTION
When encoding section sizes, tools will usually emit a patchable varuint32 value like `0xFFFFFFFF`, reserving up to 5 bytes in the stream. Once the size is known, this is patched with the real size of the section which many not necessarily to take up 5 bytes, thus tools will need to encode leading zeros bytes. LEB128 supports this, but may be surprising to people writing decoders, hence this clarification.
